### PR TITLE
refactor: never_manage constructs unbounded NeverManageObject Pool

### DIFF
--- a/examples/buffer/src/main.rs
+++ b/examples/buffer/src/main.rs
@@ -47,7 +47,7 @@ async fn main() {
 }
 
 async fn manual_put_pool() {
-    let pool = Pool::<Vec<u8>>::from_config(PoolConfig::new());
+    let pool = Pool::<Vec<u8>>::never_manage(PoolConfig::new());
     pool.put(Vec::with_capacity(1024));
 
     let mut buf = pool.get().await.unwrap();

--- a/fastpool/src/lib.rs
+++ b/fastpool/src/lib.rs
@@ -94,7 +94,7 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() {
-//! let pool = Pool::<Vec<u8>>::from_config(PoolConfig::default());
+//! let pool = Pool::<Vec<u8>>::never_manage(PoolConfig::default());
 //!
 //! let result = pool.get().await;
 //! assert_eq!(result.unwrap_err().to_string(), "unbounded pool is empty");

--- a/fastpool/src/unbounded.rs
+++ b/fastpool/src/unbounded.rs
@@ -33,7 +33,7 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() {
-//! let pool = Pool::<Vec<u8>>::from_config(PoolConfig::default());
+//! let pool = Pool::<Vec<u8>>::never_manage(PoolConfig::default());
 //!
 //! let result = pool.get().await;
 //! assert_eq!(result.unwrap_err().to_string(), "unbounded pool is empty");
@@ -234,7 +234,7 @@ where
 // Methods for `Pool` with `NeverManageObject`.
 impl<T: Send + Sync> Pool<T> {
     /// Creates a new [`Pool`] from config and the [`NeverManageObject`].
-    pub fn from_config(config: PoolConfig) -> Arc<Self> {
+    pub fn never_manage(config: PoolConfig) -> Arc<Self> {
         Self::new(config, NeverManageObject::<T>::default())
     }
 


### PR DESCRIPTION
This refers to https://github.com/fast/fastpool/issues/7